### PR TITLE
Removing Copywrite Comments

### DIFF
--- a/Descope.Test/Configuration/DescopeConfigurationTests.cs
+++ b/Descope.Test/Configuration/DescopeConfigurationTests.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeConfigurationTests" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/26/2023 21:23:06</date>
- */
-
-using RestSharp.Authenticators.OAuth2;
+﻿using RestSharp.Authenticators.OAuth2;
 
 namespace Descope.Test.Configuration
 {

--- a/Descope.Test/Configuration/EndpointsTests.cs
+++ b/Descope.Test/Configuration/EndpointsTests.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="EndpointsTests" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/26/2023 21:34:32</date>
- */
-
-using Descope.Configuration;
+﻿using Descope.Configuration;
 
 namespace Descope.Test.Configuration
 {

--- a/Descope.Test/Configuration/_Fixtures/DescopeConfigurationFixture.cs
+++ b/Descope.Test/Configuration/_Fixtures/DescopeConfigurationFixture.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeConfigurationFixture" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/27/2023 22:20:34</date>
- */
-
-using Descope.Configuration;
+﻿using Descope.Configuration;
 
 namespace Descope.Test.Configuration
 {

--- a/Descope.Test/DependencyInjection/ServiceCollectionExtensionsTests.cs
+++ b/Descope.Test/DependencyInjection/ServiceCollectionExtensionsTests.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="ServiceCollectionExtensionsTests" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/26/2023 21:40:09</date>
- */
-
-using Descope.Configuration;
+﻿using Descope.Configuration;
 using Descope.DependencyInjection;
 using Descope.HttpClient;
 using Descope.Management;

--- a/Descope.Test/DescopeApiClientTests.cs
+++ b/Descope.Test/DescopeApiClientTests.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeApiClientTests" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/27/2023 22:18:01</date>
- */
-
-using Descope.Management;
+﻿using Descope.Management;
 using NSubstitute;
 
 namespace Descope.Test

--- a/Descope.Test/HttpClient/Auth/DescopeAuthHttpClientFixture.cs
+++ b/Descope.Test/HttpClient/Auth/DescopeAuthHttpClientFixture.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeAuthHttpClientFixture" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/28/2023 21:52:46</date>
- */
-
-using Descope.HttpClient;
+﻿using Descope.HttpClient;
 using Descope.Test.Mocks;
 
 namespace Descope.Test.HttpClient.Auth

--- a/Descope.Test/HttpClient/Auth/DescopeAuthHttpClientTests.cs
+++ b/Descope.Test/HttpClient/Auth/DescopeAuthHttpClientTests.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeAuthHttpClientTests" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/28/2023 21:42:13</date>
- */
-
-using RestSharp;
+﻿using RestSharp;
 
 namespace Descope.Test.HttpClient.Auth
 {

--- a/Descope.Test/HttpClient/Management/DescopeManagementHttpClientFixture.cs
+++ b/Descope.Test/HttpClient/Management/DescopeManagementHttpClientFixture.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeManagementHttpClientFixture" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/28/2023 21:52:46</date>
- */
-
-using Descope.HttpClient;
+﻿using Descope.HttpClient;
 using Descope.Test.Mocks;
 
 namespace Descope.Test.HttpClient.Management

--- a/Descope.Test/HttpClient/Management/DescopeManagementHttpClientTests.cs
+++ b/Descope.Test/HttpClient/Management/DescopeManagementHttpClientTests.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeManagementHttpClientTests" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/28/2023 22:22:37</date>
- */
-
-using Descope.Models;
+﻿using Descope.Models;
 
 namespace Descope.Test.HttpClient.Management
 {

--- a/Descope.Test/Management/ManagementApiClientTests.cs
+++ b/Descope.Test/Management/ManagementApiClientTests.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="ManagementApiClientTests" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/28/2023 21:39:48</date>
- */
-
-using Descope.Management;
+﻿using Descope.Management;
 using Descope.Management.Permissions;
 using Descope.Management.Roles;
 using Descope.Management.Tenants;

--- a/Descope.Test/Management/Permissions/PermissionsApiClientFixture.cs
+++ b/Descope.Test/Management/Permissions/PermissionsApiClientFixture.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="PermissionsApiClientFixture" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/3/2023 20:33:30</date>
- */
-
-using Descope.Management.Permissions;
+﻿using Descope.Management.Permissions;
 
 namespace Descope.Test.Management.Permissions
 {

--- a/Descope.Test/Management/Permissions/PermissionsApiClientTests.cs
+++ b/Descope.Test/Management/Permissions/PermissionsApiClientTests.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="PermissionsApiClientTests" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/3/2023 20:34:41</date>
- */
-
-using Descope.Models;
+﻿using Descope.Models;
 
 namespace Descope.Test.Management.Permissions
 {

--- a/Descope.Test/Management/Roles/RolesApiClientFixture.cs
+++ b/Descope.Test/Management/Roles/RolesApiClientFixture.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="RolesApiClientFixture" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/6/2023 20:55:11</date>
- */
-
-using Descope.Management.Roles;
+﻿using Descope.Management.Roles;
 
 namespace Descope.Test.Management.Roles
 {

--- a/Descope.Test/Management/Roles/RolesApiClientTests.cs
+++ b/Descope.Test/Management/Roles/RolesApiClientTests.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="RolesApiClientTests" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/6/2023 20:55:29</date>
- */
-
-using Descope.Models;
+﻿using Descope.Models;
 
 namespace Descope.Test.Management.Roles
 {

--- a/Descope.Test/Management/Tenants/TenantsApiClientFixture.cs
+++ b/Descope.Test/Management/Tenants/TenantsApiClientFixture.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="TenantsApiClientFixture" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/31/2023 20:53:26</date>
- */
-
-using Descope.Management.Tenants;
+﻿using Descope.Management.Tenants;
 
 namespace Descope.Test.Management.Tenants
 {

--- a/Descope.Test/Management/Tenants/TenantsApiClientTests.cs
+++ b/Descope.Test/Management/Tenants/TenantsApiClientTests.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="TenantsApiClientTests" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/28/2023 22:34:18</date>
- */
-
-using Descope.Models;
+﻿using Descope.Models;
 
 namespace Descope.Test.Management.Tenants
 {

--- a/Descope.Test/Models/DescopeExceptionTests.cs
+++ b/Descope.Test/Models/DescopeExceptionTests.cs
@@ -1,12 +1,4 @@
-﻿/* <copyright file="DescopeExceptionTests" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/26/2023 21:57:45</date>
- */
-
-using System.Runtime.Serialization;
-using Descope.Models;
+﻿using Descope.Models;
 
 namespace Descope.Test.Models
 {

--- a/Descope.Test/Models/Permissions/DescopePermissionDeleteRequestTests.cs
+++ b/Descope.Test/Models/Permissions/DescopePermissionDeleteRequestTests.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopePermissionDeleteRequestTests" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/3/2023 20:23:43</date>
- */
-
-using Descope.Models;
+﻿using Descope.Models;
 
 namespace Descope.Test.Models.Permissions
 {

--- a/Descope.Test/Models/Permissions/DescopePermissionListResponseTests.cs
+++ b/Descope.Test/Models/Permissions/DescopePermissionListResponseTests.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopePermissionListResponseTests" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/3/2023 20:25:13</date>
- */
-
-using Descope.Models;
+﻿using Descope.Models;
 
 namespace Descope.Test.Models.Permissions
 {

--- a/Descope.Test/Models/Permissions/DescopePermissionTests.cs
+++ b/Descope.Test/Models/Permissions/DescopePermissionTests.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopePermissionTests" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/3/2023 20:22:09</date>
- */
-
-using Descope.Models;
+﻿using Descope.Models;
 
 namespace Descope.Test.Models.Permissions
 {

--- a/Descope.Test/Models/Permissions/DescopePermissionUpdateRequestTests.cs
+++ b/Descope.Test/Models/Permissions/DescopePermissionUpdateRequestTests.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopePermissionUpdateRequestTests" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/3/2023 20:24:37</date>
- */
-
-using Descope.Models;
+﻿using Descope.Models;
 
 namespace Descope.Test.Models.Permissions
 {

--- a/Descope.Test/Models/Roles/DescopeRoleDeleteRequestTests.cs
+++ b/Descope.Test/Models/Roles/DescopeRoleDeleteRequestTests.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeRoleDeleteRequestTests" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/3/2023 23:02:07</date>
- */
-
-using Descope.Models;
+﻿using Descope.Models;
 
 namespace Descope.Test.Models.Roles
 {

--- a/Descope.Test/Models/Roles/DescopeRoleListResponseTests.cs
+++ b/Descope.Test/Models/Roles/DescopeRoleListResponseTests.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeRoleListResponseTests" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/3/2023 23:05:19</date>
- */
-
-using Descope.Models;
+﻿using Descope.Models;
 
 namespace Descope.Test.Models.Roles
 {

--- a/Descope.Test/Models/Roles/DescopeRoleTests.cs
+++ b/Descope.Test/Models/Roles/DescopeRoleTests.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeRoleTests" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/3/2023 22:57:55</date>
- */
-
-using Descope.Models;
+﻿using Descope.Models;
 
 namespace Descope.Test.Models.Roles
 {

--- a/Descope.Test/Models/Roles/DescopeRoleUpdateRequestTests.cs
+++ b/Descope.Test/Models/Roles/DescopeRoleUpdateRequestTests.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeRoleUpdateRequestTests" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/3/2023 23:02:53</date>
- */
-
-using Descope.Models;
+﻿using Descope.Models;
 
 namespace Descope.Test.Models.Roles
 {

--- a/Descope.Test/Models/Tenants/DescopeTenantDeleteRequestTests.cs
+++ b/Descope.Test/Models/Tenants/DescopeTenantDeleteRequestTests.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeTenantDeleteRequestTests" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/26/2023 22:14:48</date>
- */
-
-using Descope.Models;
+﻿using Descope.Models;
 
 namespace Descope.Test.Models.Tenants
 {

--- a/Descope.Test/Models/Tenants/DescopeTenantListResponseTests.cs
+++ b/Descope.Test/Models/Tenants/DescopeTenantListResponseTests.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeTenantListResponseTests" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/26/2023 22:15:42</date>
- */
-
-using Descope.Models;
+﻿using Descope.Models;
 
 namespace Descope.Test.Models.Tenants
 {

--- a/Descope.Test/Models/Tenants/DescopeTenantSearchRequestTests.cs
+++ b/Descope.Test/Models/Tenants/DescopeTenantSearchRequestTests.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeTenantSearchRequestTests" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/26/2023 22:15:54</date>
- */
-
-using Descope.Models;
+﻿using Descope.Models;
 
 namespace Descope.Test.Models.Tenants
 {

--- a/Descope.Test/Models/Tenants/DescopeTenantTests.cs
+++ b/Descope.Test/Models/Tenants/DescopeTenantTests.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeTenantTests" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/26/2023 22:14:32</date>
- */
-
-using Descope.Models;
+﻿using Descope.Models;
 
 namespace Descope.Test.Models.Tenants
 {

--- a/Descope.Test/_Collections/ClientServerCollection.cs
+++ b/Descope.Test/_Collections/ClientServerCollection.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="ClientServerCollection" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/7/2023 21:14:59</date>
- */
-
-namespace Descope.Test
+﻿namespace Descope.Test
 {
     [CollectionDefinition("ClientServer")]
     public class ClientServerCollection : ICollectionFixture<ClientServerFixture>

--- a/Descope.Test/_Collections/ClientServerFixture.cs
+++ b/Descope.Test/_Collections/ClientServerFixture.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="ClientServerFixture" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/7/2023 21:08:17</date>
- */
-
-using Descope.HttpClient;
+﻿using Descope.HttpClient;
 using Descope.Test.Mocks;
 using WireMock.Server;
 

--- a/Descope.Test/_Collections/Extensions/ServerExtensions.cs
+++ b/Descope.Test/_Collections/Extensions/ServerExtensions.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="ServerExtensions" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/7/2023 21:13:21</date>
- */
-
-using WireMock.Server;
+﻿using WireMock.Server;
 
 namespace Descope.Test
 {

--- a/Descope.Test/_Collections/Extensions/ServerExtensions_Dummy.cs
+++ b/Descope.Test/_Collections/Extensions/ServerExtensions_Dummy.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="ServerExtensions_Dummy" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/10/2023 22:08:50</date>
- */
-
-using WireMock.Matchers;
+﻿using WireMock.Matchers;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;

--- a/Descope.Test/_Collections/Extensions/ServerExtensions_Permissions.cs
+++ b/Descope.Test/_Collections/Extensions/ServerExtensions_Permissions.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="ServerExtensions_Permissions" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/7/2023 21:19:55</date>
- */
-
-using Descope.Models;
+﻿using Descope.Models;
 using WireMock.Matchers;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;

--- a/Descope.Test/_Collections/Extensions/ServerExtensions_Roles.cs
+++ b/Descope.Test/_Collections/Extensions/ServerExtensions_Roles.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="ServerExtensions_Roles" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/7/2023 21:23:19</date>
- */
-
-using Descope.Models;
+﻿using Descope.Models;
 using WireMock.Matchers;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;

--- a/Descope.Test/_Collections/Extensions/ServerExtensions_Tenants.cs
+++ b/Descope.Test/_Collections/Extensions/ServerExtensions_Tenants.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="ServerExtensions_Tenants" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/7/2023 21:27:04</date>
- */
-
-using Descope.Models;
+﻿using Descope.Models;
 using WireMock.Matchers;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;

--- a/Descope.Test/_Mocks/IDescopeConfigurationMock.cs
+++ b/Descope.Test/_Mocks/IDescopeConfigurationMock.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="IDescopeConfigurationMock" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/28/2023 21:43:05</date>
- */
-
-using Descope.Configuration;
+﻿using Descope.Configuration;
 using NSubstitute;
 using RestSharp.Authenticators.OAuth2;
 

--- a/Descope/Configuration/DescopeConfiguration.cs
+++ b/Descope/Configuration/DescopeConfiguration.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeConfiguration" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/23/2023 20:06:45</date>
- */
-
-using RestSharp.Authenticators.OAuth2;
+﻿using RestSharp.Authenticators.OAuth2;
 
 namespace Descope.Configuration
 {

--- a/Descope/Configuration/Endpoints/Endpoints.cs
+++ b/Descope/Configuration/Endpoints/Endpoints.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="Endpoints" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/23/2023 20:45:50</date>
- */
-
-namespace Descope.Configuration
+﻿namespace Descope.Configuration
 {
     internal static class Endpoints
     {

--- a/Descope/Configuration/IDescopeConfiguration.cs
+++ b/Descope/Configuration/IDescopeConfiguration.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="IDescopeConfiguration" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/23/2023 20:06:29</date>
- */
-
-using RestSharp.Authenticators.OAuth2;
+﻿using RestSharp.Authenticators.OAuth2;
 
 namespace Descope.Configuration
 {

--- a/Descope/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Descope/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="ServiceCollectionExtensions" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/23/2023 19:18:28</date>
- */
-
-using Descope.Configuration;
+﻿using Descope.Configuration;
 using Descope.HttpClient;
 using Descope.Management;
 using Descope.Management.Permissions;

--- a/Descope/DescopeApiClient.cs
+++ b/Descope/DescopeApiClient.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeApiClient" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/23/2023 19:51:15</date>
- */
-
-using Descope.Management;
+﻿using Descope.Management;
 
 namespace Descope
 {

--- a/Descope/Extensions/RestSerializersExtensions.cs
+++ b/Descope/Extensions/RestSerializersExtensions.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="RestSerializersExtensions" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/24/2023 21:27:07</date>
- */
-
-using Descope.Models;
+﻿using Descope.Models;
 using RestSharp;
 using RestSharp.Serializers;
 

--- a/Descope/HttpClient/DescopeAuthHttpClient.cs
+++ b/Descope/HttpClient/DescopeAuthHttpClient.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeAuthHttpClient" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/23/2023 20:14:30</date>
- */
-
-using System.Text.Json;
+﻿using System.Text.Json;
 using Descope.Configuration;
 using RestSharp;
 using RestSharp.Serializers.Json;

--- a/Descope/HttpClient/DescopeManagementHttpClient.cs
+++ b/Descope/HttpClient/DescopeManagementHttpClient.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeManagementHttpClient" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/23/2023 19:58:12</date>
- */
-
-using System.Text.Json;
+﻿using System.Text.Json;
 using Descope.Configuration;
 using Descope.Extensions;
 using RestSharp;

--- a/Descope/HttpClient/Interfaces/IDescopeAuthHttpClient.cs
+++ b/Descope/HttpClient/Interfaces/IDescopeAuthHttpClient.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="IDescopeAuthHttpClient" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/23/2023 20:14:07</date>
- */
-
-using RestSharp;
+﻿using RestSharp;
 
 namespace Descope.HttpClient
 {

--- a/Descope/HttpClient/Interfaces/IDescopeManagementHttpClient.cs
+++ b/Descope/HttpClient/Interfaces/IDescopeManagementHttpClient.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="IDescopeManagementHttpClient" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/23/2023 19:57:41</date>
- */
-
-namespace Descope.HttpClient
+﻿namespace Descope.HttpClient
 {
     internal interface IDescopeManagementHttpClient : IDisposable
     {

--- a/Descope/IDescopeApiClient.cs
+++ b/Descope/IDescopeApiClient.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="IDescopeApiClient" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/23/2023 19:21:58</date>
- */
-
-using Descope.Management;
+﻿using Descope.Management;
 
 namespace Descope
 {

--- a/Descope/Management/IManagementApiClient.cs
+++ b/Descope/Management/IManagementApiClient.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="IManagementApiClient" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/23/2023 19:25:50</date>
- */
-
-using Descope.Management.Permissions;
+﻿using Descope.Management.Permissions;
 using Descope.Management.Roles;
 using Descope.Management.Tenants;
 

--- a/Descope/Management/ManagementApiClient.cs
+++ b/Descope/Management/ManagementApiClient.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="ManagementApiClient" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/23/2023 20:15:31</date>
- */
-
-using Descope.Management.Permissions;
+﻿using Descope.Management.Permissions;
 using Descope.Management.Roles;
 using Descope.Management.Tenants;
 

--- a/Descope/Management/Permissions/IPermissionsApiClient.cs
+++ b/Descope/Management/Permissions/IPermissionsApiClient.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="IPermissionsApiClient" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/3/2023 20:12:50</date>
- */
-
-using Descope.Models;
+﻿using Descope.Models;
 
 namespace Descope.Management.Permissions
 {

--- a/Descope/Management/Permissions/PermissionsApiClient.cs
+++ b/Descope/Management/Permissions/PermissionsApiClient.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="PermissionsApiClient" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/3/2023 20:12:59</date>
- */
-
-using Descope.Configuration;
+﻿using Descope.Configuration;
 using Descope.HttpClient;
 using Descope.Models;
 

--- a/Descope/Management/Roles/IRolesApiClient.cs
+++ b/Descope/Management/Roles/IRolesApiClient.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="IRolesApiClient" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/3/2023 23:11:01</date>
- */
-
-using Descope.Models;
+﻿using Descope.Models;
 
 namespace Descope.Management.Roles
 {

--- a/Descope/Management/Roles/RolesApiClient.cs
+++ b/Descope/Management/Roles/RolesApiClient.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="RolesApiClient" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/3/2023 23:11:25</date>
- */
-
-using Descope.Configuration;
+﻿using Descope.Configuration;
 using Descope.HttpClient;
 using Descope.Models;
 

--- a/Descope/Management/Tenants/ITenantsApiClient.cs
+++ b/Descope/Management/Tenants/ITenantsApiClient.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="ITenantsApiClient" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/24/2023 20:51:29</date>
- */
-
-using Descope.Models;
+﻿using Descope.Models;
 
 namespace Descope.Management.Tenants
 {

--- a/Descope/Management/Tenants/TenantsApiClient.cs
+++ b/Descope/Management/Tenants/TenantsApiClient.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="TenantsApiClient" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/24/2023 20:54:35</date>
- */
-
-using Descope.Configuration;
+﻿using Descope.Configuration;
 using Descope.HttpClient;
 using Descope.Models;
 

--- a/Descope/Models/DescopeException.cs
+++ b/Descope/Models/DescopeException.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeException" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/24/2023 21:02:34</date>
- */
-
-namespace Descope.Models
+﻿namespace Descope.Models
 {
     public class DescopeException : Exception
     {

--- a/Descope/Models/Management/Permissions/DescopePermission.cs
+++ b/Descope/Models/Management/Permissions/DescopePermission.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopePermission" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/3/2023 20:05:08</date>
- */
-
-namespace Descope.Models
+﻿namespace Descope.Models
 {
     public class DescopePermission
     {

--- a/Descope/Models/Management/Permissions/DescopePermissionDeleteRequest.cs
+++ b/Descope/Models/Management/Permissions/DescopePermissionDeleteRequest.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopePermissionDeleteRequest" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/3/2023 20:06:01</date>
- */
-
-namespace Descope.Models
+﻿namespace Descope.Models
 {
     public class DescopePermissionDeleteRequest
     {

--- a/Descope/Models/Management/Permissions/DescopePermissionListResponse.cs
+++ b/Descope/Models/Management/Permissions/DescopePermissionListResponse.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopePermissionListResponse" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/3/2023 20:12:00</date>
- */
-
-namespace Descope.Models
+﻿namespace Descope.Models
 {
     public class DescopePermissionListResponse
     {

--- a/Descope/Models/Management/Permissions/DescopePermissionUpdateRequest.cs
+++ b/Descope/Models/Management/Permissions/DescopePermissionUpdateRequest.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopePermissionUpdateRequest" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/3/2023 20:06:23</date>
- */
-
-namespace Descope.Models
+﻿namespace Descope.Models
 {
     public class DescopePermissionUpdateRequest
     {

--- a/Descope/Models/Management/Roles/DescopeRole.cs
+++ b/Descope/Models/Management/Roles/DescopeRole.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeRole" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/3/2023 22:51:18</date>
- */
-
-namespace Descope.Models
+﻿namespace Descope.Models
 {
     public class DescopeRole
     {

--- a/Descope/Models/Management/Roles/DescopeRoleDeleteRequest.cs
+++ b/Descope/Models/Management/Roles/DescopeRoleDeleteRequest.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeRoleDeleteRequest" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/3/2023 22:56:48</date>
- */
-
-namespace Descope.Models
+﻿namespace Descope.Models
 {
     public class DescopeRoleDeleteRequest
     {

--- a/Descope/Models/Management/Roles/DescopeRoleListResponse.cs
+++ b/Descope/Models/Management/Roles/DescopeRoleListResponse.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeRoleListResponse" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/3/2023 22:56:01</date>
- */
-
-namespace Descope.Models
+﻿namespace Descope.Models
 {
     public class DescopeRoleListResponse
     {

--- a/Descope/Models/Management/Roles/DescopeRoleUpdateRequest.cs
+++ b/Descope/Models/Management/Roles/DescopeRoleUpdateRequest.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeRoleUpdateRequest" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>11/3/2023 22:57:14</date>
- */
-
-namespace Descope.Models
+﻿namespace Descope.Models
 {
     public class DescopeRoleUpdateRequest
     {

--- a/Descope/Models/Management/Tenants/DescopeTenant.cs
+++ b/Descope/Models/Management/Tenants/DescopeTenant.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeTenant" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/24/2023 20:52:24</date>
- */
-
-namespace Descope.Models
+﻿namespace Descope.Models
 {
     public class DescopeTenant
     {

--- a/Descope/Models/Management/Tenants/DescopeTenantDeleteRequest.cs
+++ b/Descope/Models/Management/Tenants/DescopeTenantDeleteRequest.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeTenantDeleteRequest" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/26/2023 15:53:35</date>
- */
-
-namespace Descope.Models
+﻿namespace Descope.Models
 {
     public class DescopeTenantDeleteRequest
     {

--- a/Descope/Models/Management/Tenants/DescopeTenantListResponse.cs
+++ b/Descope/Models/Management/Tenants/DescopeTenantListResponse.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeTenantListResponse" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/26/2023 15:59:57</date>
- */
-
-namespace Descope.Models
+﻿namespace Descope.Models
 {
     public class DescopeTenantListResponse
     {

--- a/Descope/Models/Management/Tenants/DescopeTenantSearchRequest.cs
+++ b/Descope/Models/Management/Tenants/DescopeTenantSearchRequest.cs
@@ -1,11 +1,4 @@
-﻿/* <copyright file="DescopeTenantSearchRequest" company="Solidus">
- * Copyright (c) 2023 All Rights Reserved
- * </copyright>
- * <author>Solidus</author>
- * <date>10/26/2023 15:57:13</date>
- */
-
-namespace Descope.Models
+﻿namespace Descope.Models
 {
     public class DescopeTenantSearchRequest
     {


### PR DESCRIPTION
These comments were leftover from the project before it was transitioned to a public project and they are no longer relevant to it.