### PR TITLE
Removing Models from WireMock

### DIFF
--- a/Descope.Test/_Collections/Extensions/ServerExtensions_Audit.cs
+++ b/Descope.Test/_Collections/Extensions/ServerExtensions_Audit.cs
@@ -1,5 +1,4 @@
-﻿using Descope.Models;
-using WireMock.Matchers;
+﻿using WireMock.Matchers;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
@@ -8,6 +7,37 @@ namespace Descope.Test
 {
     public static class ServerExtensions_Audit
     {
+        private static readonly string[] _userIds = ["TEST"];
+        private static readonly string[] _userIdsBad = ["TESTBAD"];
+
+        private static readonly string[] _tenants = ["TEST"];
+        private static readonly string[] _externalIds = ["ExTEST"];
+
+        private static readonly object[] _audits =
+        [
+            new
+            {
+                Id = "AID",
+                ProjectId = "PTEST",
+                UserId = "UTEST",
+                Action = "Action",
+                Occurred = 34567,
+                Device = "Desktop",
+                Method = "Delete",
+                Geo = "USA",
+                RemoteAddress = "0.0.0.0",
+                ExternalIds = _externalIds,
+                Tenants = _tenants,
+                Data = new
+                {
+                    Inner = "Inner"
+                },
+                Type = "Info",
+            }
+        ];
+
+        private static readonly object[] _empty = [];
+
         public static WireMockServer SearchAudit(this WireMockServer server)
         {
             server
@@ -16,47 +46,30 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/audit/search")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeAuditSearchRequest
+                        .WithBody(new JsonMatcher(new
                         {
                             From = 12345,
                             To = 99999,
-                            UserIds = ["TEST"]
+                            UserIds = _userIds,
+                            Actions = (object)null,
+                            Devices = (object)null,
+                            ExcludedActions = (object)null,
+                            ExternalIds = (object)null,
+                            Geos = (object)null,
+                            Methods = (object)null,
+                            NoTenants = false,
+                            RemoteAddresses = (object)null,
+                            Tenants = (object)null,
+                            Text = (object)null,
                         }, true))
                 )
                 .RespondWith(
                     Response
                         .Create()
                         .WithStatusCode(200)
-                        .WithBodyAsJson(new DescopeAuditListResponse
+                        .WithBodyAsJson(new
                         {
-                            Audits =
-                            [
-                                new()
-                                {
-                                    Id = "AID",
-                                    ProjectId = "PTEST",
-                                    UserId = "UTEST",
-                                    Action = "Action",
-                                    Occurred = 34567,
-                                    Device = "Desktop",
-                                    Method = "Delete",
-                                    Geo = "USA",
-                                    RemoteAddress = "0.0.0.0",
-                                    ExternalIds =
-                                    [
-                                        "ExTEST"
-                                    ],
-                                    Tenants =
-                                    [
-                                        "TEST"
-                                    ],
-                                    Data = new
-                                    {
-                                        Inner = "Inner"
-                                    },
-                                    Type = "Info",
-                                }
-                            ]
+                            Audits = _audits
                         })
                 );
 
@@ -66,20 +79,30 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/audit/search")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeAuditSearchRequest
+                        .WithBody(new JsonMatcher(new
                         {
                             From = 12345,
                             To = 99999,
-                            UserIds = ["TESTBAD"]
+                            UserIds = _userIdsBad,
+                            Actions = (object)null,
+                            Devices = (object)null,
+                            ExcludedActions = (object)null,
+                            ExternalIds = (object)null,
+                            Geos = (object)null,
+                            Methods = (object)null,
+                            NoTenants = false,
+                            RemoteAddresses = (object)null,
+                            Tenants = (object)null,
+                            Text = (object)null,
                         }, true))
                 )
                 .RespondWith(
                     Response
                         .Create()
                         .WithStatusCode(200)
-                        .WithBodyAsJson(new DescopeAuditListResponse
+                        .WithBodyAsJson(new
                         {
-                            Audits = []
+                            Audits = _empty
                         })
                 );
 

--- a/Descope.Test/_Collections/Extensions/ServerExtensions_Flows.cs
+++ b/Descope.Test/_Collections/Extensions/ServerExtensions_Flows.cs
@@ -1,5 +1,4 @@
-﻿using Descope.Models;
-using WireMock.Matchers;
+﻿using WireMock.Matchers;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
@@ -8,7 +7,52 @@ namespace Descope.Test
 {
     public static class ServerExtensions_Flows
     {
-        private static readonly DescopeFlowMetadata _flowMetadataMock = new()
+        private static readonly string[] _empty = [];
+        private static readonly string[] _flowIds = ["TEST"];
+        private static readonly string[] _badFlowIds = ["TESTBAD"];
+
+        private static readonly string[] _translateTargetLangs = ["JP"];
+        private static readonly string[] _dependsOn = ["Dependency"];
+
+        private static readonly object[] _options =
+        [
+            new
+            {
+                Label = "Label",
+                Value = "Value"
+            }
+        ];
+
+        private static readonly object[] _inputs =
+        [
+            new
+            {
+                Type = "TEST",
+                Name = "Tester",
+                Required = false,
+                Visible = true,
+                DisplayName = "Testing",
+                DisplayType = "Test",
+                DependsOn = _dependsOn,
+                NameValueMap = (object)null,
+                ContextAware = true,
+                Options = _options
+            }
+        ];
+
+        private static readonly object[] _interactions =
+        [
+            new
+            {
+                Id = "TEST",
+                Type = "Tester",
+                Label = "Testing",
+                Icon = "Smile",
+                SubType = "Tester Jr."
+            }
+        ];
+
+        private static readonly object _flowMetadataMock = new
         {
             Id = "TEST",
             Version = 1,
@@ -24,51 +68,19 @@ namespace Descope.Test
             Translate = true,
             TranslateConnectorId = "TID",
             TranslateSourceLang = "ENG",
-            TranslateTargetLangs = ["JP"],
+            TranslateTargetLangs = _translateTargetLangs,
             Fingerprint = true,
         };
 
-        private static readonly DescopeScreen[] _screensMock =
+        private static readonly object[] _screensMock =
         [
-            new()
+            new
             {
                 Id = "TEST",
                 Version = 1,
                 FlowId = "FTEST",
-                Inputs =
-               [
-                   new()
-                   {
-                       Type = "TEST",
-                       Name = "Tester",
-                       Required = false,
-                       Visible = true,
-                       DisplayName = "Testing",
-                       DisplayType = "Test",
-                       DependsOn = ["Dependency"],
-                       NameValueMap = null,
-                       ContextAware = true,
-                       Options =
-                        [
-                            new()
-                            {
-                                Label = "Label",
-                                Value = "Value"
-                            }
-                        ]
-                   }
-               ],
-                Interactions =
-               [
-                   new()
-                   {
-                       Id = "TEST",
-                       Type = "Tester",
-                       Label = "Testing",
-                       Icon = "Smile",
-                       SubType = "Tester Jr."
-                   }
-               ],
+                Inputs = _inputs,
+                Interactions = _interactions,
                 HtmlTemplate = new
                 {
                     Inner = "Inner"
@@ -77,11 +89,7 @@ namespace Descope.Test
             }
         ];
 
-        private static readonly DescopeFlow _flowMock = new()
-        {
-            Flow = _flowMetadataMock,
-            Screens = _screensMock
-        };
+        private static readonly object[] _flows = [_flowMetadataMock];
 
         public static WireMockServer ListFlows(this WireMockServer server)
         {
@@ -91,21 +99,18 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/flow/list")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeFlowSearchRequest
+                        .WithBody(new JsonMatcher(new
                         {
-                            Ids = ["TEST"]
+                            Ids = _flowIds
                         }, true))
                 )
                 .RespondWith(
                     Response
                         .Create()
                         .WithStatusCode(200)
-                        .WithBodyAsJson(new DescopeFlowListResponse
+                        .WithBodyAsJson(new
                         {
-                            Flows =
-                            [
-                                _flowMetadataMock
-                            ],
+                            Flows = _flows,
                             Total = 1
                         })
                 );
@@ -116,21 +121,18 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/flow/list")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeFlowSearchRequest
+                        .WithBody(new JsonMatcher(new
                         {
-                            Ids = []
+                            Ids = _empty
                         }, true))
                 )
                 .RespondWith(
                     Response
                         .Create()
                         .WithStatusCode(200)
-                        .WithBodyAsJson(new DescopeFlowListResponse
+                        .WithBodyAsJson(new
                         {
-                            Flows =
-                            [
-                                _flowMetadataMock
-                            ],
+                            Flows = _flows,
                             Total = 1
                         })
                 );
@@ -141,9 +143,9 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/flow/list")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeFlowSearchRequest
+                        .WithBody(new JsonMatcher(new
                         {
-                            Ids = ["TESTBAD"]
+                            Ids = _badFlowIds
                         }, true))
                 )
                 .RespondWith(
@@ -168,7 +170,7 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/flow/export")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeFlowExportRequest
+                        .WithBody(new JsonMatcher(new
                         {
                             FlowId = "TEST"
                         }, true))
@@ -177,7 +179,11 @@ namespace Descope.Test
                     Response
                         .Create()
                         .WithStatusCode(200)
-                        .WithBodyAsJson(_flowMock)
+                        .WithBodyAsJson(new
+                        {
+                            Flow = _flowMetadataMock,
+                            Screens = _screensMock
+                        })
                 );
 
             server
@@ -186,7 +192,7 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/flow/export")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeFlowExportRequest
+                        .WithBody(new JsonMatcher(new
                         {
                             FlowId = "TESTBAD"
                         }, true))
@@ -220,23 +226,26 @@ namespace Descope.Test
                     Response
                         .Create()
                         .WithStatusCode(200)
-                        .WithBodyAsJson(new DescopeFlow
+                        .WithBodyAsJson(new
                         {
-                            Flow = new DescopeFlowMetadata
+                            Flow = new
                             {
-                                Id = _flowMetadataMock.Id,
-                                Version = _flowMetadataMock.Version + 1,
-                                Name = _flowMetadataMock.Name,
-                                Description = _flowMetadataMock.Description,
-                                Dsl = _flowMetadataMock.Dsl,
-                                ModifiedTime = _flowMetadataMock.ModifiedTime,
-                                ETag = _flowMetadataMock.ETag,
-                                Disabled = _flowMetadataMock.Disabled,
-                                Translate = _flowMetadataMock.Translate,
-                                TranslateConnectorId = _flowMetadataMock.TranslateConnectorId,
-                                TranslateSourceLang = _flowMetadataMock.TranslateSourceLang,
-                                TranslateTargetLangs = _flowMetadataMock.TranslateTargetLangs,
-                                Fingerprint = _flowMetadataMock.Fingerprint,
+                                Id = "TEST",
+                                Version = 2,
+                                Name = "Test",
+                                Description = "Testing",
+                                Dsl = new
+                                {
+                                    Inner = "Inner"
+                                },
+                                ModifiedTime = 12345,
+                                ETag = "Tagged",
+                                Disabled = false,
+                                Translate = true,
+                                TranslateConnectorId = "TID",
+                                TranslateSourceLang = "ENG",
+                                TranslateTargetLangs = _translateTargetLangs,
+                                Fingerprint = true,
                             },
                             Screens = _screensMock
                         })

--- a/Descope.Test/_Collections/Extensions/ServerExtensions_Permissions.cs
+++ b/Descope.Test/_Collections/Extensions/ServerExtensions_Permissions.cs
@@ -1,5 +1,4 @@
-﻿using Descope.Models;
-using WireMock.Matchers;
+﻿using WireMock.Matchers;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
@@ -8,6 +7,15 @@ namespace Descope.Test
 {
     public static class ServerExtensions_Permissions
     {
+        private static readonly object[] _permissions =
+        [
+            new
+            {
+                Name = "TEST",
+                Description = "Testing"
+            }
+        ];
+
         public static WireMockServer GetAllPermissions(this WireMockServer server)
         {
             server
@@ -21,16 +29,9 @@ namespace Descope.Test
                     Response
                         .Create()
                         .WithStatusCode(200)
-                        .WithBodyAsJson(new DescopePermissionListResponse
+                        .WithBodyAsJson(new
                         {
-                            Permissions =
-                            [
-                                new()
-                                {
-                                    Name = "TEST",
-                                    Description = "Testing"
-                                }
-                            ]
+                            Permissions = _permissions
                         })
                 );
 
@@ -45,10 +46,11 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/permission/create")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopePermission
+                        .WithBody(new JsonMatcher(new
                         {
                             Name = "TEST",
-                            Description = "Testing"
+                            Description = "Testing",
+                            SystemDefault = false,
                         }, true))
                 )
                 .RespondWith(
@@ -64,10 +66,11 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/permission/create")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopePermission
+                        .WithBody(new JsonMatcher(new
                         {
                             Name = "EXIST",
-                            Description = "Existing"
+                            Description = "Existing",
+                            SystemDefault = false,
                         }, true))
                 )
                 .RespondWith(
@@ -94,7 +97,7 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/permission/update")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopePermissionUpdateRequest
+                        .WithBody(new JsonMatcher(new
                         {
                             Name = "TEST",
                             NewName = "TESTU",
@@ -114,7 +117,7 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/permission/update")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopePermissionUpdateRequest
+                        .WithBody(new JsonMatcher(new
                         {
                             Name = "TEST",
                             NewName = "EXIST",
@@ -140,7 +143,7 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/permission/update")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopePermissionUpdateRequest
+                        .WithBody(new JsonMatcher(new
                         {
                             Name = "TESTBAD",
                             NewName = "TEST",
@@ -171,7 +174,7 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/permission/delete")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeNameModel
+                        .WithBody(new JsonMatcher(new
                         {
                             Name = "TEST"
                         }, true))

--- a/Descope.Test/_Collections/Extensions/ServerExtensions_Roles.cs
+++ b/Descope.Test/_Collections/Extensions/ServerExtensions_Roles.cs
@@ -1,5 +1,4 @@
-﻿using Descope.Models;
-using WireMock.Matchers;
+﻿using WireMock.Matchers;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
@@ -8,6 +7,18 @@ namespace Descope.Test
 {
     public static class ServerExtensions_Roles
     {
+        private static readonly string[] _permissions = ["TestPerm"];
+        private static readonly string[] _fakePermissions = ["FakePerm"];
+        private static readonly object[] _roles =
+        [
+            new
+            {
+                Name = "TEST",
+                Description = "Testing",
+                PermissionNames = _permissions
+            }
+        ];
+
         public static WireMockServer GetAllRoles(this WireMockServer server)
         {
             server
@@ -21,20 +32,9 @@ namespace Descope.Test
                     Response
                         .Create()
                         .WithStatusCode(200)
-                        .WithBodyAsJson(new DescopeRoleListResponse
+                        .WithBodyAsJson(new
                         {
-                            Roles =
-                            [
-                                new()
-                                {
-                                    Name = "TEST",
-                                    Description = "Testing",
-                                    PermissionNames = new string[1]
-                                    {
-                                        "TestPerm"
-                                    }
-                                }
-                            ]
+                            Roles = _roles
                         })
                 );
 
@@ -49,14 +49,12 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/role/create")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeRole
+                        .WithBody(new JsonMatcher(new
                         {
                             Name = "TEST",
                             Description = "Testing",
-                            PermissionNames =
-                            [
-                                "TestPerm"
-                            ]
+                            PermissionNames = _permissions,
+                            CreatedTime = (long)0,
                         }, true))
                 )
                 .RespondWith(
@@ -72,14 +70,12 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/role/create")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeRole
+                        .WithBody(new JsonMatcher(new
                         {
                             Name = "EXIST",
                             Description = "Existing",
-                            PermissionNames =
-                            [
-                                "TestPerm"
-                            ]
+                            PermissionNames = _permissions,
+                            CreatedTime = (long)0,
                         }, true))
                 )
                 .RespondWith(
@@ -101,14 +97,12 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/role/create")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeRole
+                        .WithBody(new JsonMatcher(new
                         {
                             Name = "TEST",
                             Description = "Testing",
-                            PermissionNames =
-                            [
-                                "FakePerm"
-                            ]
+                            PermissionNames = _fakePermissions,
+                            CreatedTime = (long)0,
                         }, true))
                 )
                 .RespondWith(
@@ -135,15 +129,12 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/role/update")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeRoleUpdateRequest
+                        .WithBody(new JsonMatcher(new
                         {
                             Name = "TEST",
                             NewName = "UTEST",
                             Description = "Testing Updated",
-                            PermissionNames =
-                            [
-                                "TestPerm"
-                            ]
+                            PermissionNames = _permissions
                         }, true))
                 )
                 .RespondWith(
@@ -159,15 +150,12 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/role/update")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeRoleUpdateRequest
+                        .WithBody(new JsonMatcher(new
                         {
                             Name = "TESTBAD",
                             NewName = "UTEST",
                             Description = "Testing Updated",
-                            PermissionNames =
-                            [
-                                "TestPerm"
-                            ]
+                            PermissionNames = _permissions
                         }, true))
                 )
                 .RespondWith(
@@ -189,15 +177,12 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/role/update")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeRoleUpdateRequest
+                        .WithBody(new JsonMatcher(new
                         {
                             Name = "TEST",
                             NewName = "EXIST",
                             Description = "Testing Updated",
-                            PermissionNames =
-                            [
-                                "TestPerm"
-                            ]
+                            PermissionNames = _permissions
                         }, true))
                 )
                 .RespondWith(
@@ -219,15 +204,12 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/role/update")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeRoleUpdateRequest
+                        .WithBody(new JsonMatcher(new
                         {
                             Name = "TEST",
                             NewName = "UTEST",
                             Description = "Testing Updated",
-                            PermissionNames =
-                            [
-                                "FakePerm"
-                            ]
+                            PermissionNames = _fakePermissions
                         }, true))
                 )
                 .RespondWith(
@@ -254,7 +236,7 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/role/delete")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeNameModel
+                        .WithBody(new JsonMatcher(new
                         {
                             Name = "TEST"
                         }, true))

--- a/Descope.Test/_Collections/Extensions/ServerExtensions_Tenants.cs
+++ b/Descope.Test/_Collections/Extensions/ServerExtensions_Tenants.cs
@@ -1,5 +1,4 @@
-﻿using Descope.Models;
-using WireMock.Matchers;
+﻿using WireMock.Matchers;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
@@ -8,19 +7,21 @@ namespace Descope.Test
 {
     public static class ServerExtensions_Tenants
     {
-        private static readonly DescopeTenant _tenantMock = new()
+        private static readonly object[] _empty = [];
+        private static readonly string[] _tenantIds = ["TEST"];
+        private static readonly string[] _badTenantIds = ["TESTBAD"];
+        private static readonly string[] _tenantNames = ["Test Client"];
+
+        private static readonly object _tenantMock = new
         {
             Id = "TEST",
             Name = "Test Client",
         };
 
-        private static readonly DescopeTenantListResponse _tenantListMock = new()
-        {
-            Tenants =
-            [
-                _tenantMock
-            ]
-        };
+        private static readonly object[] _tenantsMock =
+        [
+            _tenantMock
+        ];
 
         public static WireMockServer GetAllTenants(this WireMockServer server)
         {
@@ -35,7 +36,10 @@ namespace Descope.Test
                     Response
                         .Create()
                         .WithStatusCode(200)
-                        .WithBodyAsJson(_tenantListMock)
+                        .WithBodyAsJson(new
+                        {
+                            Tenants = _tenantsMock
+                        })
                 );
 
             return server;
@@ -90,16 +94,22 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/tenant/search")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeTenantSearchRequest
+                        .WithBody(new JsonMatcher(new
                         {
-                            TenantIds = ["TEST"]
+                            TenantIds = _tenantIds,
+                            TenantNames = (object)null,
+                            TenantSelfProvisioningDomains = (object)null,
+                            CustomAttributes = (object)null,
                         }, true))
                 )
                 .RespondWith(
                     Response
                         .Create()
                         .WithStatusCode(200)
-                        .WithBodyAsJson(_tenantListMock)
+                        .WithBodyAsJson(new
+                        {
+                            Tenants = _tenantsMock
+                        })
                 );
 
             server
@@ -108,16 +118,22 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/tenant/search")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeTenantSearchRequest
+                        .WithBody(new JsonMatcher(new
                         {
-                            TenantNames = ["Test Client"]
+                            TenantIds = (object)null,
+                            TenantNames = _tenantNames,
+                            TenantSelfProvisioningDomains = (object)null,
+                            CustomAttributes = (object)null,
                         }, true))
                 )
                 .RespondWith(
                     Response
                         .Create()
                         .WithStatusCode(200)
-                        .WithBodyAsJson(_tenantListMock)
+                        .WithBodyAsJson(new
+                        {
+                            Tenants = _tenantsMock
+                        })
                 );
 
             server
@@ -126,16 +142,22 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/tenant/search")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeTenantSearchRequest
+                        .WithBody(new JsonMatcher(new
                         {
-                            TenantIds = ["TESTBAD"]
+                            TenantIds = _badTenantIds,
+                            TenantNames = (object)null,
+                            TenantSelfProvisioningDomains = (object)null,
+                            CustomAttributes = (object)null,
                         }, true))
                 )
                 .RespondWith(
                     Response
                         .Create()
                         .WithStatusCode(200)
-                        .WithBodyAsJson(new DescopeTenantListResponse { Tenants = Array.Empty<DescopeTenant>() })
+                        .WithBodyAsJson(new
+                        {
+                            Tenants = _empty
+                        })
                 );
 
             return server;
@@ -149,10 +171,12 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/tenant/create")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeTenant
+                        .WithBody(new JsonMatcher(new
                         {
                             Id = "TEST",
-                            Name = "Test Client"
+                            Name = "Test Client",
+                            SelfProvisioningDomains = (object)null,
+                            CustomAttributes = (object)null,
                         }, true))
                 )
                 .RespondWith(
@@ -168,10 +192,12 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/tenant/create")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeTenant
+                        .WithBody(new JsonMatcher(new
                         {
                             Id = "EXIST",
-                            Name = "Existing Client"
+                            Name = "Existing Client",
+                            SelfProvisioningDomains = (object)null,
+                            CustomAttributes = (object)null,
                         }, true))
                 )
                 .RespondWith(
@@ -198,10 +224,12 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/tenant/update")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeTenant
+                        .WithBody(new JsonMatcher(new
                         {
                             Id = "TEST",
-                            Name = "Updated Client"
+                            Name = "Updated Client",
+                            SelfProvisioningDomains = (object)null,
+                            CustomAttributes = (object)null,
                         }, true))
                 )
                 .RespondWith(
@@ -217,10 +245,12 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/tenant/update")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeTenant
+                        .WithBody(new JsonMatcher(new
                         {
                             Id = "TESTBAD",
-                            Name = "Updated Client"
+                            Name = "Updated Client",
+                            SelfProvisioningDomains = (object)null,
+                            CustomAttributes = (object)null,
                         }, true))
                 )
                 .RespondWith(
@@ -247,7 +277,7 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/tenant/delete")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeIdModel
+                        .WithBody(new JsonMatcher(new
                         {
                             Id = "TEST"
                         }, true))

--- a/Descope.Test/_Collections/Extensions/ServerExtensions_Themes.cs
+++ b/Descope.Test/_Collections/Extensions/ServerExtensions_Themes.cs
@@ -1,5 +1,4 @@
-﻿using Descope.Models;
-using WireMock.RequestBuilders;
+﻿using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
 
@@ -7,26 +6,6 @@ namespace Descope.Test
 {
     public static class ServerExtensions_Themes
     {
-        private static readonly DescopeTheme _themeMock = new()
-        {
-            Id = "TEST",
-            Version = 1,
-            CssTemplate = new
-            {
-                Dark = new
-                {
-                    Font = "Fun Font",
-                    Color = "Black"
-                },
-                Light = new
-                {
-                    Font = "Less Fun Font",
-                    Color = "White"
-                }
-            },
-            ComponentsVersion = "1.0.0"
-        };
-
         public static WireMockServer ExportTheme(this WireMockServer server)
         {
             server
@@ -40,9 +19,27 @@ namespace Descope.Test
                     Response
                         .Create()
                         .WithStatusCode(200)
-                        .WithBodyAsJson(new DescopeThemeRequestResponse
+                        .WithBodyAsJson(new
                         {
-                            Theme = _themeMock
+                            Theme = new
+                            {
+                                Id = "TEST",
+                                Version = 1,
+                                CssTemplate = new
+                                {
+                                    Dark = new
+                                    {
+                                        Font = "Fun Font",
+                                        Color = "Black"
+                                    },
+                                    Light = new
+                                    {
+                                        Font = "Less Fun Font",
+                                        Color = "White"
+                                    }
+                                },
+                                ComponentsVersion = "1.0.0"
+                            }
                         })
                 );
 
@@ -62,14 +59,26 @@ namespace Descope.Test
                     Response
                         .Create()
                         .WithStatusCode(200)
-                        .WithBodyAsJson(new DescopeThemeRequestResponse
+                        .WithBodyAsJson(new
                         {
-                            Theme = new DescopeTheme
+                            Theme = new
                             {
-                                Id = _themeMock.Id,
-                                Version = _themeMock.Version + 1,
-                                CssTemplate = _themeMock.CssTemplate,
-                                ComponentsVersion = _themeMock.ComponentsVersion
+                                Id = "TEST",
+                                Version = 2,
+                                CssTemplate = new
+                                {
+                                    Dark = new
+                                    {
+                                        Font = "Fun Font",
+                                        Color = "Black"
+                                    },
+                                    Light = new
+                                    {
+                                        Font = "Less Fun Font",
+                                        Color = "White"
+                                    }
+                                },
+                                ComponentsVersion = "1.0.0"
                             }
                         })
                 );


### PR DESCRIPTION
Changing WireMock to just use anonymous objects to better simulate serialized data from Descope. Using my own models was causing serialization oddities.