### PR TITLE
Adding Support for Epoch Timestamps

### DIFF
--- a/Descope.Test/Configuration/HttpConfigurationTests.cs
+++ b/Descope.Test/Configuration/HttpConfigurationTests.cs
@@ -1,0 +1,23 @@
+﻿using System.Text.Json;
+using Descope.Configuration;
+using Descope.Types.Converters;
+
+namespace Descope.Test.Configuration
+{
+    public class HttpConfigurationTests
+    {
+        [Fact]
+        public void ShouldHaveJsonSerializerOptions()
+        {
+            var options = HttpConfigurations.JsonSerializerOptions;
+
+            Assert.NotNull(options);
+            Assert.True(options.IncludeFields);
+            Assert.True(options.PropertyNameCaseInsensitive);
+            Assert.Equal(JsonNamingPolicy.CamelCase, options.PropertyNamingPolicy);
+            Assert.Equal(2, options.Converters.Count);
+            Assert.IsType<SecondsSinceEpochJsonConverter>(options.Converters[0]);
+            Assert.IsType<MillisecondsSinceEpochConverter>(options.Converters[1]);
+        }
+    }
+}

--- a/Descope.Test/Types/MillisecondsSinceEpochTests.cs
+++ b/Descope.Test/Types/MillisecondsSinceEpochTests.cs
@@ -1,0 +1,57 @@
+﻿using Descope.Types;
+
+namespace Descope.Test.Types
+{
+    public class MillisecondsSinceEpochTests
+    {
+        [Fact]
+        public void ShouldCreateFromConstructors()
+        {
+            var secondsAsLong = new MillisecondsSinceEpoch(946684800000);
+            var secondsAsDate = new MillisecondsSinceEpoch(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+            var secondsAsDateTimeOffset = new MillisecondsSinceEpoch(new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+            Assert.Equal<long>(946684800000, secondsAsLong);
+            Assert.Equal<long>(946684800000, secondsAsDate);
+            Assert.Equal<long>(946684800000, secondsAsDateTimeOffset);
+        }
+
+        [Fact]
+        public void ShouldStringify()
+        {
+            var epoch = new MillisecondsSinceEpoch(946684800000);
+
+            Assert.Equal("946684800000", epoch.ToString());
+        }
+
+        [Fact]
+        public void ShouldConvertImplicit_long()
+        {
+            MillisecondsSinceEpoch epochFromLong = 946684800000;
+            long longFromEpoch = new MillisecondsSinceEpoch(946684800000);
+
+            Assert.Equal<long>(946684800000, epochFromLong);
+            Assert.Equal(946684800000, longFromEpoch);
+        }
+
+        [Fact]
+        public void ShouldConvertImplicit_DateTime()
+        {
+            MillisecondsSinceEpoch epochFromDateTime = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            DateTime dateTimeFromEpoch = new MillisecondsSinceEpoch(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+            Assert.Equal(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc), epochFromDateTime);
+            Assert.Equal(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc), dateTimeFromEpoch);
+        }
+
+        [Fact]
+        public void ShouldConvertImplicit_DateTimeOffset()
+        {
+            MillisecondsSinceEpoch epochFromDateTimeOffset = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            DateTimeOffset dateTimeOffsetFromEpoch = new MillisecondsSinceEpoch(new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+            Assert.Equal(new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero), epochFromDateTimeOffset);
+            Assert.Equal(new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero), dateTimeOffsetFromEpoch);
+        }
+    }
+}

--- a/Descope.Test/Types/SecondsSinceEpochTests.cs
+++ b/Descope.Test/Types/SecondsSinceEpochTests.cs
@@ -1,0 +1,57 @@
+﻿using Descope.Types;
+
+namespace Descope.Test.Types
+{
+    public class SecondsSinceEpochTests
+    {
+        [Fact]
+        public void ShouldCreateFromConstructors()
+        {
+            var secondsAsLong = new SecondsSinceEpoch(946684800);
+            var secondsAsDate = new SecondsSinceEpoch(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+            var secondsAsDateTimeOffset = new SecondsSinceEpoch(new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+            Assert.Equal(946684800, secondsAsLong);
+            Assert.Equal(946684800, secondsAsDate);
+            Assert.Equal(946684800, secondsAsDateTimeOffset);
+        }
+
+        [Fact]
+        public void ShouldStringify()
+        {
+            var epoch = new SecondsSinceEpoch(946684800);
+
+            Assert.Equal("946684800", epoch.ToString());
+        }
+
+        [Fact]
+        public void ShouldConvertImplicit_long()
+        {
+            SecondsSinceEpoch epochFromLong = 946684800;
+            long longFromEpoch = new SecondsSinceEpoch(946684800);
+
+            Assert.Equal(946684800, epochFromLong);
+            Assert.Equal(946684800, longFromEpoch);
+        }
+
+        [Fact]
+        public void ShouldConvertImplicit_DateTime()
+        {
+            SecondsSinceEpoch epochFromDateTime = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            DateTime dateTimeFromEpoch = new SecondsSinceEpoch(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+            Assert.Equal(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc), epochFromDateTime);
+            Assert.Equal(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc), dateTimeFromEpoch);
+        }
+
+        [Fact]
+        public void ShouldConvertImplicit_DateTimeOffset()
+        {
+            SecondsSinceEpoch epochFromDateTimeOffset = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            DateTimeOffset dateTimeOffsetFromEpoch = new SecondsSinceEpoch(new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+            Assert.Equal(new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero), epochFromDateTimeOffset);
+            Assert.Equal(new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero), dateTimeOffsetFromEpoch);
+        }
+    }
+}

--- a/Descope.Test/_Collections/Extensions/ServerExtensions_AccessKeys.cs
+++ b/Descope.Test/_Collections/Extensions/ServerExtensions_AccessKeys.cs
@@ -15,12 +15,12 @@ namespace Descope.Test
             new
             {
                 TenantId = "Tenant1",
-                RoleNames = new string[1] { "TenantRole1" }
+                RoleNames = new string[] { "TenantRole1" }
             },
             new
             {
                 TenantId = "Tenant2",
-                RoleNames = new string[1] { "TenantRole2" }
+                RoleNames = new string[] { "TenantRole2" }
             }
         ];
 

--- a/Descope.Test/_Collections/Extensions/ServerExtensions_AccessKeys.cs
+++ b/Descope.Test/_Collections/Extensions/ServerExtensions_AccessKeys.cs
@@ -1,5 +1,4 @@
-﻿using Descope.Models;
-using WireMock.Matchers;
+﻿using WireMock.Matchers;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
@@ -8,24 +7,29 @@ namespace Descope.Test
 {
     public static class ServerExtensions_AccessKeys
     {
-        private static readonly DescopeAccessKey _accessKeyMock = new()
+        private static readonly string[] roleNames = ["Role1"];
+        private static readonly string[] tenantIds = ["TEST"];
+        private static readonly string[] badTenantIds = ["TESTBAD"];
+        private static readonly object[] keyTenants =
+        [
+            new
+            {
+                TenantId = "Tenant1",
+                RoleNames = new string[1] { "TenantRole1" }
+            },
+            new
+            {
+                TenantId = "Tenant2",
+                RoleNames = new string[1] { "TenantRole2" }
+            }
+        ];
+
+        private static readonly object _accessKeyObjectMock = new
         {
             Id = "TEST",
             Name = "Testing",
-            RoleNames = ["Role1"],
-            KeyTenants =
-            [
-                new()
-                {
-                    TenantId = "Tenant1",
-                    RoleNames = ["TenantRole1"]
-                },
-                new()
-                {
-                    TenantId = "Tenant2",
-                    RoleNames = ["TenantRole2"]
-                }
-            ],
+            RoleNames = roleNames,
+            KeyTenants = keyTenants,
             Status = "Active",
             CreatedTime = 12345,
             ExpireTime = 99999,
@@ -62,9 +66,9 @@ namespace Descope.Test
                     Response
                         .Create()
                         .WithStatusCode(200)
-                        .WithBodyAsJson(new DescopeAccessKeyResponse
+                        .WithBodyAsJson(new
                         {
-                            Key = _accessKeyMock
+                            Key = _accessKeyObjectMock
                         })
                 );
 
@@ -115,16 +119,16 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/accesskey/search")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeAccessKeySearchRequest
+                        .WithBody(new JsonMatcher(new
                         {
-                            TenantIds = ["TEST"]
+                            TenantIds = tenantIds
                         }, true))
                 )
                 .RespondWith(
                     Response
                         .Create()
                         .WithStatusCode(200)
-                        .WithBodyAsJson(new DescopeAccessKeyListResponse { Keys = new DescopeAccessKey[1] { _accessKeyMock } })
+                        .WithBodyAsJson(new { Keys = new object[1] { _accessKeyObjectMock } })
                 );
 
             server
@@ -133,16 +137,16 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/accesskey/search")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeAccessKeySearchRequest
+                        .WithBody(new JsonMatcher(new
                         {
-                            TenantIds = ["TESTBAD"]
+                            TenantIds = badTenantIds
                         }, true))
                 )
                 .RespondWith(
                     Response
                         .Create()
                         .WithStatusCode(200)
-                        .WithBodyAsJson(new DescopeAccessKeyListResponse { Keys = Array.Empty<DescopeAccessKey>() })
+                        .WithBodyAsJson(new { Keys = Array.Empty<object>() })
                 );
 
             return server;
@@ -161,10 +165,10 @@ namespace Descope.Test
                     Response
                         .Create()
                         .WithStatusCode(200)
-                        .WithBodyAsJson(new DescopeAccessKeyCreateResponse
+                        .WithBodyAsJson(new
                         {
                             ClearText = "Secret",
-                            Key = _accessKeyMock
+                            Key = _accessKeyObjectMock
                         })
                 );
 
@@ -179,7 +183,7 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/accesskey/update")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeAccessKeyUpdateRequest
+                        .WithBody(new JsonMatcher(new
                         {
                             Id = "TEST",
                             Name = "Updated Testing"
@@ -189,18 +193,18 @@ namespace Descope.Test
                     Response
                         .Create()
                         .WithStatusCode(200)
-                        .WithBodyAsJson(new DescopeAccessKeyResponse
+                        .WithBodyAsJson(new
                         {
-                            Key = new()
+                            Key = new
                             {
-                                Id = _accessKeyMock.Id,
+                                Id = "TEST",
                                 Name = "Updated Testing",
-                                RoleNames = _accessKeyMock.RoleNames,
-                                KeyTenants = _accessKeyMock.KeyTenants,
-                                Status = _accessKeyMock.Status,
-                                CreatedTime = _accessKeyMock.CreatedTime,
-                                ExpireTime = _accessKeyMock.ExpireTime,
-                                CreatedBy = _accessKeyMock.CreatedBy
+                                RoleNames = roleNames,
+                                KeyTenants = keyTenants,
+                                Status = "Active",
+                                CreatedTime = 12345,
+                                ExpireTime = 99999,
+                                CreatedBy = "Mr. Tester"
                             }
                         })
                 );
@@ -211,7 +215,7 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/accesskey/update")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeAccessKeyUpdateRequest
+                        .WithBody(new JsonMatcher(new
                         {
                             Id = "TESTBAD",
                             Name = "Updated Testing"
@@ -235,7 +239,7 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/accesskey/activate")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeIdModel
+                        .WithBody(new JsonMatcher(new
                         {
                             Id = "TEST"
                         }, true))
@@ -253,7 +257,7 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/accesskey/activate")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeIdModel
+                        .WithBody(new JsonMatcher(new
                         {
                             Id = "TESTBAD"
                         }, true))
@@ -276,7 +280,7 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/accesskey/deactivate")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeIdModel
+                        .WithBody(new JsonMatcher(new
                         {
                             Id = "TEST"
                         }, true))
@@ -294,7 +298,7 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/accesskey/deactivate")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeIdModel
+                        .WithBody(new JsonMatcher(new
                         {
                             Id = "TESTBAD"
                         }, true))
@@ -317,7 +321,7 @@ namespace Descope.Test
                         .Create()
                         .WithPath("/v1/mgmt/accesskey/delete")
                         .UsingPost()
-                        .WithBody(new JsonMatcher(new DescopeIdModel
+                        .WithBody(new JsonMatcher(new
                         {
                             Id = "TEST"
                         }, true))

--- a/Descope/Configuration/HttpConfiguration/HttpConfigurations.cs
+++ b/Descope/Configuration/HttpConfiguration/HttpConfigurations.cs
@@ -1,0 +1,20 @@
+﻿using System.Text.Json;
+using Descope.Types.Converters;
+
+namespace Descope.Configuration
+{
+    internal static class HttpConfigurations
+    {
+        internal static readonly JsonSerializerOptions JsonSerializerOptions = new()
+        {
+            IncludeFields = true,
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters =
+            {
+                new SecondsSinceEpochJsonConverter(),
+                new MillisecondsSinceEpochConverter()
+            }
+        };
+    }
+}

--- a/Descope/HttpClient/DescopeAuthHttpClient.cs
+++ b/Descope/HttpClient/DescopeAuthHttpClient.cs
@@ -1,6 +1,4 @@
-﻿using System.Text.Json;
-using Descope.Configuration;
-using Descope.Types.Converters;
+﻿using Descope.Configuration;
 using RestSharp;
 using RestSharp.Serializers.Json;
 
@@ -17,17 +15,7 @@ namespace Descope.HttpClient
                 Authenticator = config.AuthApiAuthenticator
             };
 
-            _client = new RestClient(options, configureSerialization: x => x.UseSystemTextJson(new JsonSerializerOptions
-            {
-                IncludeFields = true,
-                PropertyNameCaseInsensitive = true,
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                Converters =
-                {
-                    new SecondsSinceEpochJsonConverter(),
-                    new MillisecondsSinceEpochConverter(),
-                }
-            }));
+            _client = new RestClient(options, configureSerialization: x => x.UseSystemTextJson(HttpConfigurations.JsonSerializerOptions));
         }
 
         public RestClient Client => _client;

--- a/Descope/HttpClient/DescopeAuthHttpClient.cs
+++ b/Descope/HttpClient/DescopeAuthHttpClient.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json;
 using Descope.Configuration;
+using Descope.Types.Converters;
 using RestSharp;
 using RestSharp.Serializers.Json;
 
@@ -21,6 +22,11 @@ namespace Descope.HttpClient
                 IncludeFields = true,
                 PropertyNameCaseInsensitive = true,
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                Converters =
+                {
+                    new SecondsSinceEpochJsonConverter(),
+                    new MillisecondsSinceEpochConverter(),
+                }
             }));
         }
 

--- a/Descope/HttpClient/DescopeManagementHttpClient.cs
+++ b/Descope/HttpClient/DescopeManagementHttpClient.cs
@@ -1,7 +1,5 @@
-﻿using System.Text.Json;
-using Descope.Configuration;
+﻿using Descope.Configuration;
 using Descope.Extensions;
-using Descope.Types.Converters;
 using RestSharp;
 using RestSharp.Serializers.Json;
 
@@ -18,17 +16,7 @@ namespace Descope.HttpClient
                 Authenticator = config.ManagementApiAuthenticator
             };
 
-            _client = new RestClient(options, configureSerialization: x => x.UseSystemTextJson(new JsonSerializerOptions
-            {
-                IncludeFields = true,
-                PropertyNameCaseInsensitive = true,
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                Converters =
-                {
-                    new SecondsSinceEpochJsonConverter(),
-                    new MillisecondsSinceEpochConverter(),
-                }
-            }));
+            _client = new RestClient(options, configureSerialization: x => x.UseSystemTextJson(HttpConfigurations.JsonSerializerOptions));
         }
 
         public async Task<TResponse> GetAsync<TResponse>(string resource, object parameters = null) where TResponse : class, new()

--- a/Descope/HttpClient/DescopeManagementHttpClient.cs
+++ b/Descope/HttpClient/DescopeManagementHttpClient.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json;
 using Descope.Configuration;
 using Descope.Extensions;
+using Descope.Types.Converters;
 using RestSharp;
 using RestSharp.Serializers.Json;
 
@@ -22,6 +23,11 @@ namespace Descope.HttpClient
                 IncludeFields = true,
                 PropertyNameCaseInsensitive = true,
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                Converters =
+                {
+                    new SecondsSinceEpochJsonConverter(),
+                    new MillisecondsSinceEpochConverter(),
+                }
             }));
         }
 

--- a/Descope/Models/Management/AccessKeys/DescopeAccessKey.cs
+++ b/Descope/Models/Management/AccessKeys/DescopeAccessKey.cs
@@ -1,4 +1,6 @@
-﻿namespace Descope.Models
+﻿using Descope.Types;
+
+namespace Descope.Models
 {
     public class DescopeAccessKey
     {
@@ -7,8 +9,8 @@
         public IEnumerable<string> RoleNames { get; set; }
         public IEnumerable<DescopeAccessKeyTenant> KeyTenants { get; set; }
         public string Status { get; set; }
-        public long CreatedTime { get; set; }
-        public long ExpireTime { get; set; }
+        public SecondsSinceEpoch CreatedTime { get; set; }
+        public SecondsSinceEpoch ExpireTime { get; set; }
         public string CreatedBy { get; set; }
     }
 }

--- a/Descope/Models/Management/AccessKeys/DescopeAccessKeyCreateRequest.cs
+++ b/Descope/Models/Management/AccessKeys/DescopeAccessKeyCreateRequest.cs
@@ -1,9 +1,11 @@
-﻿namespace Descope.Models
+﻿using Descope.Types;
+
+namespace Descope.Models
 {
     public class DescopeAccessKeyCreateRequest
     {
         public string Name { get; set; }
-        public long ExpireTime { get; set; }
+        public SecondsSinceEpoch ExpireTime { get; set; }
         public IEnumerable<string> RoleNames { get; set; }
         public IEnumerable<DescopeAccessKeyTenant> KeyTenants { get; set; }
     }

--- a/Descope/Models/Management/Audit/DescopeAudit.cs
+++ b/Descope/Models/Management/Audit/DescopeAudit.cs
@@ -1,4 +1,6 @@
-﻿namespace Descope.Models
+﻿using Descope.Types;
+
+namespace Descope.Models
 {
     public class DescopeAudit
     {
@@ -6,7 +8,7 @@
         public string ProjectId { get; set; }
         public string UserId { get; set; }
         public string Action { get; set; }
-        public long Occurred { get; set; }
+        public MillisecondsSinceEpoch Occurred { get; set; }
         public string Device { get; set; }
         public string Method { get; set; }
         public string Geo { get; set; }

--- a/Descope/Models/Management/Audit/DescopeAuditSearchRequest.cs
+++ b/Descope/Models/Management/Audit/DescopeAuditSearchRequest.cs
@@ -1,9 +1,11 @@
-﻿namespace Descope.Models
+﻿using Descope.Types;
+
+namespace Descope.Models
 {
     public class DescopeAuditSearchRequest
     {
-        public long From { get; set; }
-        public long To { get; set; }
+        public MillisecondsSinceEpoch From { get; set; }
+        public MillisecondsSinceEpoch To { get; set; }
         public IEnumerable<string> UserIds { get; set; }
         public IEnumerable<string> Actions { get; set; }
         public IEnumerable<string> Devices { get; set; }

--- a/Descope/Models/Management/Flows/DescopeFlowMetadata.cs
+++ b/Descope/Models/Management/Flows/DescopeFlowMetadata.cs
@@ -1,4 +1,6 @@
-﻿namespace Descope.Models
+﻿using Descope.Types;
+
+namespace Descope.Models
 {
     public class DescopeFlowMetadata
     {
@@ -7,7 +9,7 @@
         public string Name { get; set; }
         public string Description { get; set; }
         public object Dsl { get; set; }
-        public long ModifiedTime { get; set; }
+        public SecondsSinceEpoch ModifiedTime { get; set; }
         public string ETag { get; set; }
         public bool Disabled { get; set; }
         public bool Translate { get; set; }

--- a/Descope/Models/Management/Roles/DescopeRole.cs
+++ b/Descope/Models/Management/Roles/DescopeRole.cs
@@ -1,10 +1,12 @@
-﻿namespace Descope.Models
+﻿using Descope.Types;
+
+namespace Descope.Models
 {
     public class DescopeRole
     {
         public string Name { get; set; }
         public string Description { get; set; }
         public IEnumerable<string> PermissionNames { get; set; }
-        public long CreatedTime { get; private set; }
+        public SecondsSinceEpoch CreatedTime { get; private set; }
     }
 }

--- a/Descope/Types/Converters/MillisecondsSinceEpochConverter.cs
+++ b/Descope/Types/Converters/MillisecondsSinceEpochConverter.cs
@@ -1,0 +1,25 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Descope.Types.Converters
+{
+    internal class MillisecondsSinceEpochConverter : JsonConverter<MillisecondsSinceEpoch>
+    {
+        public override MillisecondsSinceEpoch Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TryGetInt64(out long millisecondsSinceEpoch))
+            {
+                return millisecondsSinceEpoch;
+            }
+            else
+            {
+                throw new JsonException("Unable to convert value to MillisecondsSinceEpoch.");
+            }
+        }
+
+        public override void Write(Utf8JsonWriter writer, MillisecondsSinceEpoch value, JsonSerializerOptions options)
+        {
+            writer.WriteNumberValue(value);
+        }
+    }
+}

--- a/Descope/Types/Converters/SecondsSinceEpochJsonConverter.cs
+++ b/Descope/Types/Converters/SecondsSinceEpochJsonConverter.cs
@@ -1,0 +1,25 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Descope.Types.Converters
+{
+    internal class SecondsSinceEpochJsonConverter : JsonConverter<SecondsSinceEpoch>
+    {
+        public override SecondsSinceEpoch Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TryGetInt64(out long secondsSinceEpoch))
+            {
+                return secondsSinceEpoch;
+            }
+            else
+            {
+                throw new JsonException("Unable to convert value to SecondsSinceEpoch.");
+            }
+        }
+
+        public override void Write(Utf8JsonWriter writer, SecondsSinceEpoch value, JsonSerializerOptions options)
+        {
+            writer.WriteNumberValue(value);
+        }
+    }
+}

--- a/Descope/Types/MillisecondsSinceEpoch.cs
+++ b/Descope/Types/MillisecondsSinceEpoch.cs
@@ -1,0 +1,28 @@
+﻿namespace Descope.Types
+{
+    public readonly struct MillisecondsSinceEpoch(long seconds)
+    {
+        private readonly long _seconds = seconds;
+
+        public MillisecondsSinceEpoch(DateTime date) : this(new DateTimeOffset(date.ToUniversalTime()))
+        {
+
+        }
+
+        public MillisecondsSinceEpoch(DateTimeOffset offset) : this(offset.ToUnixTimeMilliseconds())
+        {
+
+        }
+
+        public static implicit operator long(MillisecondsSinceEpoch s) => s._seconds;
+        public static implicit operator MillisecondsSinceEpoch(long l) => new(l);
+
+        public static implicit operator DateTime(MillisecondsSinceEpoch s) => DateTimeOffset.FromUnixTimeMilliseconds(s._seconds).DateTime;
+        public static implicit operator MillisecondsSinceEpoch(DateTime d) => new(d);
+
+        public static implicit operator DateTimeOffset(MillisecondsSinceEpoch s) => DateTimeOffset.FromUnixTimeMilliseconds(s._seconds);
+        public static implicit operator MillisecondsSinceEpoch(DateTimeOffset d) => new(d);
+
+        public override string ToString() => _seconds.ToString();
+    }
+}

--- a/Descope/Types/MillisecondsSinceEpoch.cs
+++ b/Descope/Types/MillisecondsSinceEpoch.cs
@@ -4,7 +4,7 @@
     {
         private readonly long _seconds = seconds;
 
-        public MillisecondsSinceEpoch(DateTime date) : this(new DateTimeOffset(date.ToUniversalTime()))
+        public MillisecondsSinceEpoch(DateTime date) : this(new DateTimeOffset(date))
         {
 
         }

--- a/Descope/Types/SecondsSinceEpoch.cs
+++ b/Descope/Types/SecondsSinceEpoch.cs
@@ -4,7 +4,7 @@
     {
         private readonly long _seconds = seconds;
 
-        public SecondsSinceEpoch(DateTime date) : this(new DateTimeOffset(date.ToUniversalTime()))
+        public SecondsSinceEpoch(DateTime date) : this(new DateTimeOffset(date))
         {
 
         }

--- a/Descope/Types/SecondsSinceEpoch.cs
+++ b/Descope/Types/SecondsSinceEpoch.cs
@@ -1,0 +1,28 @@
+﻿namespace Descope.Types
+{
+    public readonly struct SecondsSinceEpoch(long seconds)
+    {
+        private readonly long _seconds = seconds;
+
+        public SecondsSinceEpoch(DateTime date) : this(new DateTimeOffset(date.ToUniversalTime()))
+        {
+
+        }
+
+        public SecondsSinceEpoch(DateTimeOffset offset) : this(offset.ToUnixTimeSeconds())
+        {
+
+        }
+
+        public static implicit operator long(SecondsSinceEpoch s) => s._seconds;
+        public static implicit operator SecondsSinceEpoch(long l) => new(l);
+
+        public static implicit operator DateTime(SecondsSinceEpoch s) => DateTimeOffset.FromUnixTimeSeconds(s._seconds).DateTime;
+        public static implicit operator SecondsSinceEpoch(DateTime d) => new(d);
+
+        public static implicit operator DateTimeOffset(SecondsSinceEpoch s) => DateTimeOffset.FromUnixTimeSeconds(s._seconds);
+        public static implicit operator SecondsSinceEpoch(DateTimeOffset d) => new(d);
+
+        public override string ToString() => _seconds.ToString();
+    }
+}


### PR DESCRIPTION
Descope returns timestamps as either seconds since epoch or milliseconds since epoch.  This PR adds custom structs for both types of data.  These structs can be implicitly converted between `long`, `DateTime` and `DateTimeOffset` which will enable consumers to consume/map these timestamps in whatever format fits their needs.